### PR TITLE
[packaging] droid-compat-f5321-hybris-libsensorfw-qt5: require rpm-di…

### DIFF
--- a/rpm/droid-compat-f5321.spec
+++ b/rpm/droid-compat-f5321.spec
@@ -29,6 +29,7 @@
 
 %package hybris-libsensorfw-qt5
 Summary: Quirks for hybris-libsensorfw-qt5
+Requires: rpm-divert
 Requires: hybris-libsensorfw-qt5
 
 %description hybris-libsensorfw-qt5


### PR DESCRIPTION
…vert

Signed-off-by: Eugenio Paolantonio (g7) <me@medesimo.eu>